### PR TITLE
:ambulance: fix COLUMN_PATTERN to make annotation work for column with Japanese characters

### DIFF
--- a/lib/annotate_rb/model_annotator/annotation_diff_generator.rb
+++ b/lib/annotate_rb/model_annotator/annotation_diff_generator.rb
@@ -11,7 +11,13 @@ module AnnotateRb
       #   - "#  status(a/b/c)    :string           not null"
       #   - "#  created_at       :datetime         not null"
       #   - "#  updated_at       :datetime         not null"
-      COLUMN_PATTERN = /^#[\t ]+[\w*.`\[\]():]+(?:\(.*?\))?[\t ]+.+$/
+
+      # Original pattern was excluding the columns with comments containing Japanese characters
+      # see:
+      # COLUMN_PATTERN = /^#[\t ]+[\w*.`\[\]():]+(?:\(.*?\))?[\t ]+.+$/
+
+      # Modified pattern to include columns with comments containing Japanese characters
+      COLUMN_PATTERN = /^#[\t ]+[\w*.`\[\]():]+[\t ]+.+$/
 
       class << self
         def call(file_content, annotation_block)

--- a/lib/annotate_rb/model_annotator/annotation_diff_generator.rb
+++ b/lib/annotate_rb/model_annotator/annotation_diff_generator.rb
@@ -12,12 +12,11 @@ module AnnotateRb
       #   - "#  created_at       :datetime         not null"
       #   - "#  updated_at       :datetime         not null"
 
-      # Original pattern was excluding the columns with comments containing Japanese characters
+      # Original pattern was excluding the columns with comments containing Japanese characters.
+      # Use \p{Word} instead of \w to include Japanese characters.
       # see:
       # COLUMN_PATTERN = /^#[\t ]+[\w*.`\[\]():]+(?:\(.*?\))?[\t ]+.+$/
-
-      # Modified pattern to include columns with comments containing Japanese characters
-      COLUMN_PATTERN = /^#[\t ]+[\w*.`\[\]():]+[\t ]+.+$/
+      COLUMN_PATTERN = /^#[\t ]+[\p{Word}*.`\[\]():]+(?:\(.*?\))?[\t ]+.+$/
 
       class << self
         def call(file_content, annotation_block)


### PR DESCRIPTION
# Problem
Annotations were not generated for columns containing Japanese characters because of the set COLUMN_PATTERN regex.

```bash
[1] pry(main)> COLUMN_PATTERN = /^#[\t ]+[\w*.`\[\]():]+[\t ]+.+$/
=> /^#[\t ]+[\w*.`\[\]():]+[\t ]+.+$/
[2] pry(main)> new_annotations = "# Table name: posts\n +
#\n +
#  id              :uuid             not null, primary key\n +
#  title(タイトル) :string           not null\n +
#  content(内容)   :text             not null\n +
#  created_at      :datetime         not null\n +
#  updated_at      :datetime         not null\n +
[2] pry(main)> new_annotations = "# Table name: posts\n +
#\n +
#  id              :uuid             not null, primary key\n +
#  title(タイトル) :string           not null\n +
#  content(内容)   :text             not null\n +
#  created_at      :datetime         not null\n +
#  updated_at      :datetime         not null\n +
#  memo(メモ)      :text\n +
#\n
=> "# Table name: posts\n +\n#\n +\n#  id              :uuid             not null, primary key\n +\n#  title(タイトル) :string           not null\n +\n#  content(内容)   :text             not null\n +\n#  created_at      :datetime         not null\n +\n#  updated_at      :datetime         not null\n +\n#  memo(メモ)      :text\n +\n#\n\n"
[3] pry(main)> new_annotations.scan(COLUMN_PATTERN).sort
[3] pry(main)> new_annotations.scan(COLUMN_PATTERN).sort

=> ["#  created_at      :datetime         not null",
 "#  id              :uuid             not null, primary key",
 "#  updated_at      :datetime         not null",
 "# Table name: posts"]
```

We can see the lines with Japanese characters are not detected.

# Solution
Modify the regex so that Japanese characters are also included.
```bash
[9] pry(main)> COLUMN_PATTERN = /^#[\t ]+[\p{Word}*.`\[\]():]+(?:\(.*?\))?[\t ]+.+$/
=> /^#[\t ]+[\p{Word}*.`\[\]():]+(?:\(.*?\))?[\t ]+.+$/
[10] pry(main)> new_annotations.scan(COLUMN_PATTERN).sort
=> ["#  content(内容)   :text             not null",
 "#  created_at      :datetime         not null",
 "#  id              :uuid             not null, primary key",
 "#  memo(メモ)      :text",
 "#  title(タイトル) :string           not null",
 "#  updated_at      :datetime         not null",
 "# Table name: posts"]
```